### PR TITLE
chore: add package support links

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
 		"type": "git",
 		"url": "git+https://github.com/porada/prettier-plugin-markdown-html.git"
 	},
+	"homepage": "https://github.com/porada/prettier-plugin-markdown-html#readme",
+	"bugs": {
+		"url": "https://github.com/porada/prettier-plugin-markdown-html/issues"
+	},
 	"keywords": [
 		"formatting",
 		"gfm",


### PR DESCRIPTION
## Summary
- add `homepage` metadata pointing to the project README
- add `bugs.url` metadata pointing to the repository issue tracker
- leave runtime code, dependencies, package files, and version unchanged

## Validation
- package metadata assertion for `name`, `repository`, `homepage`, and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
